### PR TITLE
Feature: added the endpoint to fetch quiz  questions

### DIFF
--- a/src/main/java/com/ak/onlinequiz/controller/QuizController.java
+++ b/src/main/java/com/ak/onlinequiz/controller/QuizController.java
@@ -8,10 +8,13 @@ import com.ak.onlinequiz.entity.Question;
 import com.ak.onlinequiz.entity.Quiz;
 import com.ak.onlinequiz.repository.QuizRepository;
 import com.ak.onlinequiz.service.QuizService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/quiz")
@@ -31,5 +34,11 @@ public class QuizController {
     public ResponseEntity<QuestionResponse> addQuestions(@PathVariable Long quizId, @RequestBody QuestionRequest request){
         QuestionResponse question=quizService.addQuestionsToQuiz(quizId,request);
         return ResponseEntity.status(HttpStatus.CREATED).body(question);
+    }
+
+    @GetMapping("/{quizId}/fetchQuestion")
+    public ResponseEntity<List<QuestionResponse>> fetchQuestionsForQuiz(@PathVariable Long quizId){
+        List<QuestionResponse> question=quizService.fetchQuestionOfQuiz(quizId);
+        return ResponseEntity.status(HttpStatus.OK).body(question);
     }
 }

--- a/src/main/java/com/ak/onlinequiz/dto/OptionResponse.java
+++ b/src/main/java/com/ak/onlinequiz/dto/OptionResponse.java
@@ -6,6 +6,7 @@ import lombok.*;
 @Setter
 @AllArgsConstructor
 @Builder
+@NoArgsConstructor
 public class OptionResponse {
     private Long id;
     private String optionText;

--- a/src/main/java/com/ak/onlinequiz/entity/Question.java
+++ b/src/main/java/com/ak/onlinequiz/entity/Question.java
@@ -1,14 +1,16 @@
 package com.ak.onlinequiz.entity;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.util.List;
 
 @Entity
 @Builder
-@Data
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Question {
 
     @Id

--- a/src/main/java/com/ak/onlinequiz/repository/QuestionRepository.java
+++ b/src/main/java/com/ak/onlinequiz/repository/QuestionRepository.java
@@ -1,7 +1,13 @@
 package com.ak.onlinequiz.repository;
 
+import com.ak.onlinequiz.dto.QuestionResponse;
 import com.ak.onlinequiz.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface QuestionRepository extends JpaRepository<Question,Long> {
+    @Query("SELECT q FROM Question q JOIN FETCH q.optionList WHERE q.quiz.id = :quizId")
+    List<Question> findByQuizId(Long quizId);
 }

--- a/src/main/java/com/ak/onlinequiz/repository/QuizRepository.java
+++ b/src/main/java/com/ak/onlinequiz/repository/QuizRepository.java
@@ -1,7 +1,10 @@
 package com.ak.onlinequiz.repository;
 
+import com.ak.onlinequiz.entity.Question;
 import com.ak.onlinequiz.entity.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 
 public interface QuizRepository extends JpaRepository<Quiz,Long> {

--- a/src/main/java/com/ak/onlinequiz/service/QuizService.java
+++ b/src/main/java/com/ak/onlinequiz/service/QuizService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,14 +22,14 @@ public class QuizService {
     private final QuizRepository quizRepo;
     private final QuestionRepository questionRepo;
 
-    public QuizResponse createQuiz(CreateQuizRequest request){
-        Quiz quiz=Quiz.builder()
+    public QuizResponse createQuiz(CreateQuizRequest request) {
+        Quiz quiz = Quiz.builder()
                 .title(request.getTitle())
                 .createdAt(LocalDateTime.now())
                 .build();
-        Quiz saveQuiz=quizRepo.save(quiz);
+        Quiz saveQuiz = quizRepo.save(quiz);
 
-        QuizResponse response=QuizResponse.builder()
+        QuizResponse response = QuizResponse.builder()
                 .id(saveQuiz.getId())
                 .title(saveQuiz.getTitle())
                 .createdAt(saveQuiz.getCreatedAt())
@@ -36,47 +37,80 @@ public class QuizService {
         return response;
     }
 
-    public QuestionResponse addQuestionsToQuiz(Long id, QuestionRequest questionRequest){
+    public QuestionResponse addQuestionsToQuiz(Long id, QuestionRequest questionRequest) {
         // get the quiz object by id to make reference to question
-        Quiz quiz=quizRepo.findById(id)
-                .orElseThrow(()-> new EntityNotFoundException("Quiz not found with this id "+id));
+        Quiz quiz = quizRepo.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Quiz not found with this id " + id));
 
         // create a question object
-        Question addQuestion=Question.builder()
+        Question addQuestion = Question.builder()
                 .questionText(questionRequest.getQuestionText())
                 .quiz(quiz)
                 .build();
 
         // create list to store the MCQ's
-        List<MultipleOption> multipleOptions=new ArrayList<>();
+        List<MultipleOption> multipleOptions = new ArrayList<>();
 
         // get the options from OptionRequest class which is reference to QuestionRequest class and save to MultipleOption
-        for (OptionRequest optionRequest:questionRequest.getOptionRequestList()){
-            MultipleOption option=new MultipleOption();
+        for (OptionRequest optionRequest : questionRequest.getOptionRequestList()) {
+            MultipleOption option = new MultipleOption();
             option.setOptionText(optionRequest.getOptionText());
             option.setCorrect(optionRequest.isCorrect());
             option.setQuestion(addQuestion);
             multipleOptions.add(option);
         }
         addQuestion.setOptionList(multipleOptions);
-        Question savedQuestion=questionRepo.save(addQuestion); // save to repository
+        Question savedQuestion = questionRepo.save(addQuestion); // save to repository
 
         // now convert to DTO for security concern and Infinite loop breaking
-        List<OptionResponse> optionResponses=new ArrayList<>();
+        List<OptionResponse> optionResponses = new ArrayList<>();
 
-        for (MultipleOption option: savedQuestion.getOptionList()){
-            OptionResponse response= OptionResponse.builder()
+        for (MultipleOption option : savedQuestion.getOptionList()) {
+            OptionResponse response = OptionResponse.builder()
                     .id(option.getId())
                     .optionText(option.getOptionText())
                     .build();
             optionResponses.add(response);
         }
         // convert to DTO
-        QuestionResponse response= QuestionResponse.builder()
+        QuestionResponse response = QuestionResponse.builder()
                 .id(savedQuestion.getId())
                 .questionText(savedQuestion.getQuestionText())
                 .optionResponses(optionResponses)
                 .build();
+
+        return response;
+    }
+
+
+    public List<QuestionResponse> fetchQuestionOfQuiz(Long quizId) {
+        Quiz quiz = quizRepo.findById(quizId)
+                .orElseThrow(() -> new EntityNotFoundException("Quiz Not found!!"));
+
+        // Store the questions
+        List<Question> questions = questionRepo.findByQuizId(quizId);
+        // create a object to store in DTO
+        List<QuestionResponse> response = new ArrayList<>();
+
+        // run a for loop
+        for (Question que : questions) {
+            //create a DTO to store the options
+            List<OptionResponse> optionResponses = new ArrayList<>();
+
+            for (MultipleOption multipleOption : que.getOptionList()) {
+                OptionResponse opt = new OptionResponse();
+                opt.setId(multipleOption.getId());
+                opt.setOptionText(multipleOption.getOptionText());
+                optionResponses.add(opt); // save the options in DTO
+            }
+            // create a object of QuestionResponse to show the questions
+            QuestionResponse qr = QuestionResponse.builder()
+                    .id(que.getId())
+                    .questionText(que.getQuestionText())
+                    .optionResponses(optionResponses)
+                    .build();
+            response.add(qr); // add in List of questions
+        }
 
         return response;
     }


### PR DESCRIPTION
### Key Changes
-   **`QuizService`:** Added a `fetchQuestionOfQuiz()` method to fetch questions and map them to DTOs.
-   **`QuestionRepository`:** Implemented a `findByQuizId()` method with a `JOIN FETCH` query to prevent lazy loading issues. (the _`id`_ associated with options are null that's why `JOIN FETCH` is used.
-   **`QuizController`:** Created a new endpoint at `GET /api/quiz/{quizId}/fetchQuestion`.
-   **DTOs:** The response uses the existing `QuestionResponse` and `OptionResponse` DTOs to ensure the correct answer (_`isCorrext`_ field) is not shown to user.
